### PR TITLE
Improve extractContentId

### DIFF
--- a/web/src/utils/FairplayUtils.ts
+++ b/web/src/utils/FairplayUtils.ts
@@ -5,6 +5,13 @@ export function extractContentId(skdUrl: string): string {
     if (questionMarkIndex >= 0) {
         return skdUrl.substr(questionMarkIndex + 1);
     } else {
+        const strippedSkd = skdUrl.split('skd://').pop();
+        if (strippedSkd) {
+            const base64regex = /^([0-9a-zA-Z+/]{4})*(([0-9a-zA-Z+/]{2}==)|([0-9a-zA-Z+/]{3}=))?$/;
+            if (base64regex.test(strippedSkd)) {
+                return strippedSkd;
+            }
+        }
         const chunks = skdUrl.split('/');
         return chunks[chunks.length - 1];
     }


### PR DESCRIPTION
We had a case where the contentId contained a ` /` which caused us to extract it wrongly. This change will make it a bit more robust.